### PR TITLE
Integrate maven-publish gradle plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2.2.0
+    - name: Set up JDK
+      uses: actions/setup-java@v1.3.0
+      with:
+        java-version: 11
+    - name: Publish with Gradle
+      run: ./gradlew publish
+      env:
+        PGP_SIGNING_KEY: ${{ secrets.PGP_SIGNING_KEY }}
+        PGP_SIGNING_PASSWORD: ${{ secrets.PGP_SIGNING_PASSWORD }}
+        SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,13 @@ plugins {
 	id 'checkstyle'
 	id 'java-library'
 	id 'jacoco'
+	id 'maven-publish'
+	id 'signing'
 	id 'org.sonarqube' version '2.8'
 }
 
 repositories {
-	jcenter()
+	mavenCentral()
 }
 
 checkstyle {
@@ -37,24 +39,14 @@ compileTestJava {
 	targetCompatibility = 1.8
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
-	classifier = 'sources'
-	from sourceSets.main.allSource
+java {
+	withJavadocJar()
+	withSourcesJar()
 }
 
 javadoc {
 	include '**/horseshoe/*.java'
 	title = 'Horseshoe'
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-	classifier = 'javadoc'
-	from javadoc.destinationDir
-}
-
-artifacts {
-	archives sourcesJar
-	archives javadocJar
 }
 
 jacocoTestReport {
@@ -77,8 +69,9 @@ def getVersion = { ->
 	return stdout.toString().trim().substring(1)
 }
 
-group = 'oss.horseshoe'
-version = getVersion()
+// Run gradle with "-Dsnapshot=true" to enable snapshots
+def isSnapshot = Boolean.getBoolean('snapshot')
+version = getVersion() + (isSnapshot ? '-SNAPSHOT' : '')
 
 jar {
 	manifest {
@@ -92,4 +85,66 @@ tasks.withType(Jar) {
 	from('LICENSE') {
 		into 'META-INF'
 	}
+}
+
+publishing {
+	repositories {
+		maven {
+			url = { isSnapshot ? snapshotRepositoryUrl : releaseRepositoryUrl }
+			credentials {
+				username = System.getenv('SONATYPE_USER')
+				password = System.getenv('SONATYPE_PASSWORD')
+			}
+		}
+	}
+	publications {
+		sonatype(MavenPublication) {
+			artifactId = artifact
+			from components.java
+			pom {
+				def repository = System.getenv('GITHUB_REPOSITORY')
+				def repoUrl = System.getenv('GITHUB_SERVER_URL') + "/${repository}"
+				def baseRepoUrl = repoUrl.substring('https://'.length())
+				name = 'Horseshoe'
+				description = 'Horseshoe for Java'
+				url = repoUrl
+				organization {
+					name = group
+					url = repoUrl.substring(0, repoUrl.lastIndexOf('/'))
+				}
+				issueManagement {
+					system = 'GitHub'
+					url = "${repoUrl}/issues"
+				}
+				licenses {
+					license {
+						name = 'MIT License'
+						url = "${repoUrl}/blob/master/LICENSE"
+					}
+				}
+				scm {
+					connection = "scm:git:git://${baseRepoUrl}.git"
+					developerConnection = "scm:git:ssh://${baseRepoUrl}.git"
+					url = repoUrl
+				}
+				withXml {
+					def devs = asNode().appendNode('developers')
+					def authors = (file('AUTHORS').text =~ /(.*?) <(.*?)>/).findAll()
+					authors.each {
+						def dev = devs.appendNode('developer')
+						dev.appendNode('name', it[1])
+						dev.appendNode('email', it[2])
+					}
+				}
+			}
+		}
+	}
+}
+
+signing {
+	required = { gradle.taskGraph.hasTask('uploadArchives') }
+	def signingKey = System.getenv('PGP_SIGNING_KEY')
+	def signingPassword = System.getenv('PGP_SIGNING_PASSWORD')
+	useInMemoryPgpKeys(signingKey, signingPassword)
+	sign publishing.publications
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+group=com.github.horseshoe
+artifact=horseshoe
+releaseRepositoryUrl=https\://oss.sonatype.org/service/local/staging/deploy/maven2/
+snapshotRepositoryUrl=https\://oss.sonatype.org/content/repositories/snapshots/


### PR DESCRIPTION
Action items before leaving draft stage:

- [x] Add project secret `SONATYPE_USER` with the horseshoe Sonatype account username

- [x] Add project secret `SONATYPE_TOKEN` or `SONATYPE_PASSWORD` with the horseshoe Sonatype account password / authentication token
- [x] Add project secret `PGP_SIGNING_KEY` (acquired via `gpg --armor --export-secret-keys`) in the form of
```
-----BEGIN PGP PRIVATE KEY BLOCK-----

BLAHBLAHBLAH
-----END PGP PRIVATE KEY BLOCK-----
```
- [x] Add project secret `PGP_SIGNING_PASSWORD` for the previous `PGP_SIGNING_KEY`
- [x] Change `publishToMavenLocal` to `publish`
- [x] Change workflow action to type releases