### PR TITLE
End Bigotry

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,10 +7,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 9 * * 5'
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,7 +3,7 @@ name: Coverity
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin
 .classpath
 .project
 .settings
+.vscode

--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 
 Nick Little <nicklaus.little@gmail.com>
 Thomas Bateson <thomas.bateson@eagles.oc.edu>
+Troy Southard <009101@gmail.com>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Horseshoe for Java is a templating system used to generate source code and other
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=horseshoe_horseshoe&metric=vulnerabilities)](https://sonarcloud.io/dashboard?id=horseshoe_horseshoe)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=horseshoe_horseshoe&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=horseshoe_horseshoe)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=horseshoe_horseshoe&metric=alert_status)](https://sonarcloud.io/dashboard?id=horseshoe_horseshoe)
-[![license](https://img.shields.io/github/license/horseshoe/horseshoe?label=License&logo=github)](https://github.com/horseshoe/horseshoe/blob/master/LICENSE)
+[![license](https://img.shields.io/github/license/horseshoe/horseshoe?label=License&logo=github)](https://github.com/horseshoe/horseshoe/blob/main/LICENSE)
 
 ## Goals
 - Provide a Mustache-like template engine for generating source code.

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ publishing {
 				licenses {
 					license {
 						name = 'MIT License'
-						url = "${repoUrl}/blob/master/LICENSE"
+						url = "${repoUrl}/blob/main/LICENSE"
 					}
 				}
 				scm {


### PR DESCRIPTION
Converted default branch references to 'main' to align with GitHub's Code of Conduct. 
See https://github.com/github/renaming

I agree to horseshoe's license. 