### PR TITLE
Refactor add operator

### DIFF
--- a/src/main/java/horseshoe/internal/Expression.java
+++ b/src/main/java/horseshoe/internal/Expression.java
@@ -87,9 +87,10 @@ public final class Expression {
 	private static final Method STREAMABLE_FLAT_ADD_ARRAY = getMethod(Streamable.class, "flatAdd", Object[].class);
 	private static final Method STREAMABLE_FLAT_ADD_ITERABLE = getMethod(Streamable.class, "flatAdd", Iterable.class);
 	private static final Method STREAMABLE_OF_UNKNOWN = getMethod(Streamable.class, "ofUnknown", Object.class);
-	private static final Method STRING_BUILDER_APPEND_OBJECT = getMethod(StringBuilder.class, "append", Object.class);
+	private static final Method STRING_BUILDER_APPEND_STRING = getMethod(StringBuilder.class, "append", String.class);
 	private static final Constructor<?> STRING_BUILDER_INIT_STRING = getConstructor(StringBuilder.class, String.class);
 	private static final Method STRING_VALUE_OF = getMethod(String.class, "valueOf", Object.class);
+	private static final Method UTILITIES_REQUIRE_NON_NULL_TO_STRING = getMethod(Utilities.class, "requireNonNullToString", Object.class);
 
 	// The patterns used for parsing the grammar
 	private static final Pattern COMMENT_PATTERN = Pattern.compile("(?:/(?s:/[^\\n\\x0B\\x0C\\r\\u0085\\u2028\\u2029]*|[*].*?[*]/)\\s*)", Pattern.UNICODE_CHARACTER_CLASS);
@@ -699,9 +700,9 @@ public final class Expression {
 				if (left == null) { // Unary +, basically do nothing except require a number
 					state.getOperands().push(new Operand(Double.class, right.toNumeric(true)));
 				} else if (StringBuilder.class.equals(left.type)) { // Check for string concatenation
-					state.getOperands().push(left).peek().builder.append(right.toObject()).addInvoke(STRING_BUILDER_APPEND_OBJECT);
+					state.getOperands().push(left).peek().builder.append(right.toObject()).addInvoke(UTILITIES_REQUIRE_NON_NULL_TO_STRING).addInvoke(STRING_BUILDER_APPEND_STRING);
 				} else if (String.class.equals(left.type) || String.class.equals(right.type) || StringBuilder.class.equals(right.type)) {
-					state.getOperands().push(new Operand(StringBuilder.class, left.toObject().pushNewObject(StringBuilder.class).addCode(DUP_X1, SWAP).addInvoke(STRING_VALUE_OF).addInvoke(STRING_BUILDER_INIT_STRING).append(right.toObject()).addInvoke(STRING_BUILDER_APPEND_OBJECT)));
+					state.getOperands().push(new Operand(StringBuilder.class, left.toObject().pushNewObject(StringBuilder.class).addCode(DUP_X1, SWAP).addInvoke(STRING_VALUE_OF).addInvoke(STRING_BUILDER_INIT_STRING).append(right.toObject()).addInvoke(UTILITIES_REQUIRE_NON_NULL_TO_STRING).addInvoke(STRING_BUILDER_APPEND_STRING)));
 				} else { // String concatenation, mathematical addition, collection addition, or invalid
 					state.getOperands().push(new Operand(Object.class, left.toObject().append(right.toObject()).addInvoke(OPERANDS_ADD)));
 				}

--- a/src/main/java/horseshoe/internal/Operands.java
+++ b/src/main/java/horseshoe/internal/Operands.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -32,68 +33,95 @@ public final class Operands {
 				return add(toNumeric(left), toNumeric(right));
 			}
 		} else if (left instanceof String) {
-			return (String)left + right;
+			if (right == null) {
+				throw new NullPointerException("Invalid objects cannot be concatenated: \"" + left + "\" + null");
+			}
+			return (String)left + right.toString();
 		} else if (left instanceof Set) {
 			if (right instanceof Collection) {
 				final Set<Object> result = new LinkedHashSet<>((Set<?>)left);
 
 				result.addAll((Collection<?>)right);
 				return result;
-			} else if (right instanceof Map) {
-				final Map<?, ?> rightMap = (Map<?, ?>)right;
-				final Map<Object, Object> result = new LinkedHashMap<>(rightMap.size());
+			} else if (right instanceof Iterable) {
+				final Set<Object> result = new LinkedHashSet<>((Set<?>)left);
 
-				for (final Object object : (Set<?>)left) {
-					result.put(object, object);
+				for (final Object object : (Iterable<?>)right) {
+					result.add(object);
 				}
 
-				result.putAll(rightMap);
 				return result;
 			}
 		} else if (left instanceof Collection) {
-			if (right instanceof Set) {
-				final Set<Object> result = new LinkedHashSet<>((Collection<?>)left);
+			final Collection<?> leftCollection = (Collection<?>)left;
 
-				result.addAll((Set<?>)right);
+			if (right instanceof Set) {
+				final Set<?> rightSet = (Set<?>)right;
+				final Set<Object> result = new LinkedHashSet<>(leftCollection);
+
+				result.addAll(rightSet);
 				return result;
 			} else if (right instanceof Collection) {
-				final Collection<?> leftCollection = (Collection<?>)left;
 				final Collection<?> rightCollection = (Collection<?>)right;
 				final List<Object> result = new ArrayList<>(leftCollection.size() + rightCollection.size());
 
 				result.addAll(leftCollection);
 				result.addAll(rightCollection);
 				return result;
-			} else if (right instanceof Map) {
-				final Map<?, ?> rightMap = (Map<?, ?>)right;
-				final Map<Object, Object> result = new LinkedHashMap<>(rightMap.size());
+			} else if (right instanceof Iterable) {
+				final List<Object> result = new ArrayList<>(leftCollection);
 
-				for (final Object object : (Collection<?>)left) {
-					result.put(object, object);
+				for (final Object object : (Iterable<?>)right) {
+					result.add(object);
 				}
 
-				result.putAll(rightMap);
 				return result;
 			}
-		} else if (left instanceof Map) {
-			if (right instanceof Map) {
-				final Map<Object, Object> result = new LinkedHashMap<>((Map<?, ?>)left);
+		} else if (left instanceof Iterable) {
+			if (right instanceof Set) {
+				final Set<?> rightSet = (Set<?>)right;
+				final Set<Object> result = new LinkedHashSet<>(rightSet.size());
 
-				result.putAll((Map<?, ?>)right);
+				for (final Object object : (Iterable<?>)left) {
+					result.add(object);
+				}
+
+				result.addAll(rightSet);
 				return result;
 			} else if (right instanceof Collection) {
-				final Map<Object, Object> result = new LinkedHashMap<>((Map<?, ?>)left);
+				final Collection<?> rightCollection = (Collection<?>)right;
+				final List<Object> result = new ArrayList<>(rightCollection.size());
 
-				for (final Object object : (Collection<?>)right) {
-					result.put(object, object);
+				for (final Object object : (Iterable<?>)left) {
+					result.add(object);
+				}
+
+				result.addAll(rightCollection);
+				return result;
+			} else if (right instanceof Iterable) {
+				final List<Object> result = new ArrayList<>();
+
+				for (final Object object : (Iterable<?>)left) {
+					result.add(object);
+				}
+				for (final Object object : (Iterable<?>)right) {
+					result.add(object);
 				}
 
 				return result;
 			}
+		} else if (left instanceof Map && right instanceof Map) {
+			final Map<Object, Object> result = new LinkedHashMap<>((Map<?, ?>)left);
+
+			result.putAll((Map<?, ?>)right);
+			return result;
 		}
 
 		if (right instanceof String) {
-			return left + (String)right;
+			if (left == null) {
+				throw new NullPointerException("Invalid objects cannot be concatenated: null + \"" + right + '"');
+			}
+			return left.toString() + (String)right;
 		}
 
 		throw new IllegalArgumentException("Invalid objects cannot be added: " + (left == null ? "null" : left.getClass().getName()) + " + " + (right == null ? "null" : right.getClass().getName()));
@@ -356,6 +384,12 @@ public final class Operands {
 			return ((Collection<?>)container).contains(item);
 		} else if (container instanceof Map) {
 			return ((Map<?, ?>)container).containsKey(item);
+		} else if (container instanceof Iterable) {
+			for (final Object object : (Iterable<?>)container) {
+				if (Objects.equals(object, item)) {
+					return true;
+				}
+			}
 		}
 
 		return false;

--- a/src/main/java/horseshoe/internal/Utilities.java
+++ b/src/main/java/horseshoe/internal/Utilities.java
@@ -201,6 +201,20 @@ public final class Utilities {
 	}
 
 	/**
+	 * Returns the result of calling {@code toString} for a non-{@code null} argument and throws an exception if object is {@code null}. Used for constructing {@link StringBuilder}s or invoking {@link StringBuilder#append(String)}.
+	 *
+	 * @param object an {@code Object}
+	 * @return the result of calling {@code toString} for a non-{@code null} argument
+	 * @throws NullPointerException if the object is {@code null}
+	 */
+	public static String requireNonNullToString(final Object object) {
+		if (object == null) {
+			throw new NullPointerException("Invalid object cannot be concatenated: null");
+		}
+		return object.toString();
+	}
+
+	/**
 	 * Gets the trimmed string from the specified starting index.
 	 *
 	 * @param value the string to trim


### PR DESCRIPTION
1. Changed Collection/Map operator add behavior as shown below (cases not shown below are errors):
  - Set + Collection = Set
  - Set + Iterable = Set
  - Collection + Set = Set
  - Collection + Collection = List
  - Collection + Iterable = List
  - Iterable + Set = Set
  - Iterable + Collection = List
  - Iterable + Iterable = List
  - Map + Map = Map

2. Changed String concatenation behavior, now `String + null` = `String.toString() + ""` instead of previously `String.toString() + "null"`