### PR TITLE
Partial name resolution with expressions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,11 @@
 	"java.sources.organizeImports.starThreshold": 99,
 	"java.sources.organizeImports.staticStarThreshold": 99,
 	"java.completion.importOrder": [
+		"#java",
+		"#javax",
+		"#com",
+		"#horseshoe",
+		"#org",
 		"java",
 		"javax",
 		"com",

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Explicit levels within the context stack can be referenced by prefixing an ident
 Unescaped content (`{{{ content }}}`, `{{& content }}`) is the same as normal content in Horseshoe, since content is not escaped by default. It only differs from normal content if content escaping is enabled. The tag can either start with a `{` and end with a `}` or simply start with a `&`.
 
 #### Partials
-Partial tags (`{{> partial }}`) are similar to partial tags in Mustache. They function similarly to a `#include` directive in C++ but providing appropriate scoping. The partial template is loaded (either from the specified filename or the corresponding template from the template loader) and placed into the current template.
+Partial tags (`{{> partial }}`) are similar to partial tags in Mustache. They function similarly to a `#include` directive in C++ but providing appropriate scoping. The partial template is loaded either from the specified filename or the corresponding template from the template loader. If the lookup name is not known until render-time, its value can be computed with a [expression](#expressions) (`{{> (expression) }}`). Once loaded, the partial is placed into the current template.
 
 If a partial tag is a stand-alone tag, the indentation of the partial tag will be prepended to every line of the partial template. <b>Using a double arrow partial tag (`{{>> partial }}`) will avoid applying the indentation to every line but will still ignore the trailing whitespace and newline after the partial.</b>
 
@@ -219,9 +219,10 @@ Inline partial tags (`{{< partial }}`) define a partial template inline in the c
 
 Inline partials can have named parameters ([template bindings](#template-bindings)). The first parameter can be specified as a literal `.` to indicate the value will be pushed onto the context stack.
 
-Inline partials can only be included (using a [partial tag](#partials)) from the declaring template. This prevents naming collisions with inline partials in other templates. Passing arguments to an inline partial is done as an [expression](#expressions). For example,
+Inline partials can only be included (using a [partial tag](#partials)) from the declaring template. This prevents naming collisions with inline partials in other templates. Passing arguments to an inline partial or computing its name is done as an [expression](#expressions). For example,
 ```horseshoe
 {{> MyPartial(1 + 1, 'second arg') }}
+{{> ('My' + 'Partial')(1 + 1, 'second arg') }}
 ```
 
 <b>Closing tags for inline partials are always considered stand-alone tags for trailing whitespace purposes even if other content precedes them.</b> This allows inline partials to end without a trailing newline and not cause an output line in the current template.

--- a/src/main/java/horseshoe/TemplateLoadState.java
+++ b/src/main/java/horseshoe/TemplateLoadState.java
@@ -187,7 +187,7 @@ final class TemplateLoadState {
 		if (size > 1 || tagCount == 1) {
 			final String removedWhitespace = priorStaticText.get(size - 1).getLine();
 
-			if (Utilities.isWhitespace(removedWhitespace)) {
+			if (removedWhitespace != null && Utilities.isWhitespace(removedWhitespace)) {
 				priorStaticText.set(size - 1, new ParsedLine(null, ""));
 				return removedWhitespace;
 			}

--- a/src/main/java/horseshoe/TemplateRenderer.java
+++ b/src/main/java/horseshoe/TemplateRenderer.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import horseshoe.internal.Expression;
 
-final class TemplateRenderer extends TagRenderer {
+class TemplateRenderer extends TagRenderer {
 
 	private final Template template;
 	private final String indentation;
@@ -20,6 +20,11 @@ final class TemplateRenderer extends TagRenderer {
 
 	TemplateRenderer(final Template template, final String indentation) {
 		this(template, indentation, null);
+	}
+
+	TemplateRenderer(final String indentation, final boolean standalone, final TemplateRenderer deferred) {
+		this(deferred.template, indentation, deferred.expression);
+		setStandalone(standalone);
 	}
 
 	@Override

--- a/src/test/java/horseshoe/PartialsTests.java
+++ b/src/test/java/horseshoe/PartialsTests.java
@@ -215,6 +215,22 @@ class PartialsTests {
 	}
 
 	@Test
+	void testInlinePartials5() throws IOException, LoadException {
+		assertEquals("123", Template.load("{{< ab }}123{{/}}{{> ('a' + 'b') }}").render(Collections.emptyMap(), new StringWriter()).toString());
+		assertEquals("  123" + LS + "  zzz" + LS, Template.load("{{< ab }}\n123\nzzz\n{{/}}\n  {{> ('a' + 'b') }}").render(Collections.emptyMap(), new StringWriter()).toString());
+		assertEquals("  123" + LS + "zzz" + LS, Template.load("{{< ab }}\n123\nzzz\n{{/}}  {{> ('a' + 'b') }}").render(Collections.emptyMap(), new StringWriter()).toString());
+		assertEquals("  123" + LS + "zzz" + LS, Template.load("{{< ab }}\n123\nzzz\n{{/}}\n  {{>> ('a' + 'b') }}").render(Collections.emptyMap(), new StringWriter()).toString());
+		assertEquals("456", Template.load("{{< ab }}456{{/}}{{> (s = ''; ['A', 'B'] #> i -> i.toLowerCase() #< i -> s = s + i; s) }}").render(Collections.emptyMap(), new StringWriter()).toString());
+		assertEquals("789", Template.load("{{< ab }}789{{/}}{{> (key) }}").render(Collections.singletonMap("key", "ab"), new StringWriter()).toString());
+		assertEquals("1011", Template.load("{{< ab }}1011{{/}}{{ Exp() -> 'ab' }}{{> (Exp()) }}").render(Collections.emptyMap(), new StringWriter()).toString());
+		assertEquals("123hi", Template.load("{{< ab }}123{{>}}{{/}}{{#> ('a' + 'b') }}hi{{/}}").render(Collections.emptyMap(), new StringWriter()).toString());
+		assertEquals("456hello", Template.load("{{< ab }}456{{>}}{{/}}{{#> (s = ''; ['A', 'B'] #> i -> i.toLowerCase() #< i -> s = s + i; s) }}hello{{/}}").render(Collections.emptyMap(), new StringWriter()).toString());
+		assertEquals("", Template.load("{{> ('a' + '') }}").render(Collections.emptyMap(), new StringWriter()).toString());
+		assertEquals("", Template.load("{{> (noexists) }}").render(Collections.emptyMap(), new StringWriter()).toString());
+		assertEquals("123", Template.load("{{< ab(x, y, z) }}{{ x }}{{ y }}{{ z }}{{/}}{{> ('a' + 'B'.toLowerCase())(0 + 1, 1 + 1, 1 + 2) }}").render(Collections.emptyMap(), new StringWriter()).toString());
+	}
+
+	@Test
 	void testInlinePartialIndentation() throws IOException, LoadException {
 		assertEquals("ab" + LS + "\tab" + LS, Template.load("{{< a }}\na{{# b }}b{{/ b }}\n{{/}}\n{{> a }}\n\t{{> a }}\n").render(Collections.singletonMap("b", true), new StringWriter()).toString());
 	}


### PR DESCRIPTION
This PR introduces dynamic partial name resolution.
```handlebars
{{ < ab }}123 abc{{/ ab }}
{{> ('a' + 'b') }}
```
Outputs: `123 abc`

Partial expressions must be surrounded by parentheses.
```handlebars 
{{> (expression) }} 
{{> (expression)(arguments) }} 
```

Tested with Expressions, Named Expressions, and Context.